### PR TITLE
Explicit support for Motion Plus controllers

### DIFF
--- a/source/patcher/hooks_patcher_static.cpp
+++ b/source/patcher/hooks_patcher_static.cpp
@@ -107,12 +107,13 @@ DECL_FUNCTION(void, WPADRead, WPADChan chan, WPADStatusProController *data) {
 
     if (!sConfigMenuOpened && data[0].err == 0) {
         if (data[0].extensionType != 0xFF) {
-            if (data[0].extensionType == WPAD_EXT_CORE || data[0].extensionType == WPAD_EXT_NUNCHUK) {
+            if (data[0].extensionType == WPAD_EXT_CORE || data[0].extensionType == WPAD_EXT_NUNCHUK ||
+                data[0].extensionType == WPAD_EXT_MPLUS || data[0].extensionType == WPAD_EXT_MPLUS_NUNCHUK) {
                 // button data is in the first 2 bytes for wiimotes
                 if (((uint16_t *) data)[0] == (WPAD_BUTTON_B | WPAD_BUTTON_DOWN | WPAD_BUTTON_MINUS)) {
                     sWantsToOpenConfigMenu = true;
                 }
-            } else if (data[0].extensionType == WPAD_EXT_CLASSIC) {
+            } else if (data[0].extensionType == WPAD_EXT_CLASSIC || data[0].extensionType == WPAD_EXT_MPLUS_CLASSIC) {
                 // TODO: figure out the real struct..
                 if ((((uint32_t *) data)[10] & 0xFFFF) == (WPAD_CLASSIC_BUTTON_L | WPAD_CLASSIC_BUTTON_DOWN | WPAD_CLASSIC_BUTTON_MINUS)) {
                     sWantsToOpenConfigMenu = true;

--- a/source/utils/input/WPADInput.h
+++ b/source/utils/input/WPADInput.h
@@ -144,7 +144,8 @@ public:
             return false;
         }
 
-        if (kpad.extensionType == WPAD_EXT_CORE || kpad.extensionType == WPAD_EXT_NUNCHUK) {
+        if (kpad.extensionType == WPAD_EXT_CORE || kpad.extensionType == WPAD_EXT_NUNCHUK ||
+            kpad.extensionType == WPAD_EXT_MPLUS || kpad.extensionType == WPAD_EXT_MPLUS_NUNCHUK) {
             data.buttons_r = remapWiiMoteButtons(kpad.release);
             data.buttons_h = remapWiiMoteButtons(kpad.hold);
             data.buttons_d = remapWiiMoteButtons(kpad.trigger);


### PR DESCRIPTION
Fixes opening and navigating the plugin config menu in Wii Sports Club with a Motion Plus controller.