### PR TITLE
Use left/right to jump a full page on the toplevel menu.

### DIFF
--- a/source/utils/config/ConfigRenderer.cpp
+++ b/source/utils/config/ConfigRenderer.cpp
@@ -75,15 +75,27 @@ ConfigSubState ConfigRenderer::UpdateStateMain(const Input &input) {
     if (input.data.buttons_d & Input::eButtons::BUTTON_DOWN) {
         mCursorPos++;
     } else if (input.data.buttons_d & Input::eButtons::BUTTON_LEFT) {
-        mCursorPos -= MAX_BUTTONS_ON_SCREEN;
-        // avoid wraparound when moving whole page
-        if (mCursorPos < 0)
-            mCursorPos = 0;
+        // Paging up
+        if (mCursorPos == 0) {
+            // cursor at top pos, behaves as if pressed up
+            mCursorPos--;
+        } else {
+            mCursorPos -= MAX_BUTTONS_ON_SCREEN;
+            // otherwise, don't jump past the top
+            if (mCursorPos < 0)
+                mCursorPos = 0;
+        }
     } else if (input.data.buttons_d & Input::eButtons::BUTTON_RIGHT) {
-        mCursorPos += MAX_BUTTONS_ON_SCREEN;
-        // avoid wraparound when moving whole page
-        if (mCursorPos >= totalElementSize)
-            mCursorPos = totalElementSize - 1;
+        // Paging down
+        if (mCursorPos == totalElementSize - 1) {
+            // cursor at bottom pos, behaves as if pressed down
+            mCursorPos++;
+        } else {
+            mCursorPos += MAX_BUTTONS_ON_SCREEN;
+            // otherwise, don't jump past the bottom
+            if (mCursorPos >= totalElementSize)
+                mCursorPos = totalElementSize - 1;
+        }
     } else if (input.data.buttons_d & Input::eButtons::BUTTON_UP) {
         mCursorPos--;
     } else if (input.data.buttons_d & Input::eButtons::BUTTON_A) {

--- a/source/utils/config/ConfigRenderer.cpp
+++ b/source/utils/config/ConfigRenderer.cpp
@@ -27,7 +27,7 @@ void ConfigRenderer::RenderStateMain() const {
     // draw bottom bar
     DrawUtils::drawRectFilled(8, SCREEN_HEIGHT - 24 - 8 - 4, SCREEN_WIDTH - 8 * 2, 3, COLOR_BLACK);
     DrawUtils::setFontSize(18);
-    DrawUtils::print(16, SCREEN_HEIGHT - 10, "\ue07d Navigate ");
+    DrawUtils::print(16, SCREEN_HEIGHT - 10, "\ue07d/\ue07e Navigate ");
     DrawUtils::print(SCREEN_WIDTH - 16, SCREEN_HEIGHT - 10, "\ue000 Select", true);
 
     // draw scroll indicator
@@ -71,9 +71,19 @@ ConfigSubState ConfigRenderer::UpdateStateMain(const Input &input) {
     }
     auto prevSelectedItem = mCursorPos;
 
-    auto totalElementSize = mConfigs.size();
+    int32_t totalElementSize = mConfigs.size();
     if (input.data.buttons_d & Input::eButtons::BUTTON_DOWN) {
         mCursorPos++;
+    } else if (input.data.buttons_d & Input::eButtons::BUTTON_LEFT) {
+        mCursorPos -= MAX_BUTTONS_ON_SCREEN;
+        // avoid wraparound when moving whole page
+        if (mCursorPos < 0)
+            mCursorPos = 0;
+    } else if (input.data.buttons_d & Input::eButtons::BUTTON_RIGHT) {
+        mCursorPos += MAX_BUTTONS_ON_SCREEN;
+        // avoid wraparound when moving whole page
+        if (mCursorPos >= totalElementSize)
+            mCursorPos = totalElementSize - 1;
     } else if (input.data.buttons_d & Input::eButtons::BUTTON_UP) {
         mCursorPos--;
     } else if (input.data.buttons_d & Input::eButtons::BUTTON_A) {
@@ -95,8 +105,8 @@ ConfigSubState ConfigRenderer::UpdateStateMain(const Input &input) {
     }
 
     if (mCursorPos < 0) {
-        mCursorPos = (int32_t) totalElementSize - 1;
-    } else if (mCursorPos > (int32_t) (totalElementSize - 1)) {
+        mCursorPos = totalElementSize - 1;
+    } else if (mCursorPos > totalElementSize - 1) {
         mCursorPos = 0;
     }
 

--- a/source/utils/config/ConfigRenderer.cpp
+++ b/source/utils/config/ConfigRenderer.cpp
@@ -71,31 +71,21 @@ ConfigSubState ConfigRenderer::UpdateStateMain(const Input &input) {
     }
     auto prevSelectedItem = mCursorPos;
 
-    int32_t totalElementSize = mConfigs.size();
+    auto totalElementSize = (int32_t) mConfigs.size();
     if (input.data.buttons_d & Input::eButtons::BUTTON_DOWN) {
         mCursorPos++;
     } else if (input.data.buttons_d & Input::eButtons::BUTTON_LEFT) {
         // Paging up
-        if (mCursorPos == 0) {
-            // cursor at top pos, behaves as if pressed up
-            mCursorPos--;
-        } else {
-            mCursorPos -= MAX_BUTTONS_ON_SCREEN;
-            // otherwise, don't jump past the top
-            if (mCursorPos < 0)
-                mCursorPos = 0;
-        }
+        mCursorPos -= MAX_BUTTONS_ON_SCREEN - 1;
+        // Don't jump past the top
+        if (mCursorPos < 0)
+            mCursorPos = 0;
     } else if (input.data.buttons_d & Input::eButtons::BUTTON_RIGHT) {
         // Paging down
-        if (mCursorPos == totalElementSize - 1) {
-            // cursor at bottom pos, behaves as if pressed down
-            mCursorPos++;
-        } else {
-            mCursorPos += MAX_BUTTONS_ON_SCREEN;
-            // otherwise, don't jump past the bottom
-            if (mCursorPos >= totalElementSize)
-                mCursorPos = totalElementSize - 1;
-        }
+        mCursorPos += MAX_BUTTONS_ON_SCREEN - 1;
+        // Don't jump past the bottom
+        if (mCursorPos >= totalElementSize)
+            mCursorPos = totalElementSize - 1;
     } else if (input.data.buttons_d & Input::eButtons::BUTTON_UP) {
         mCursorPos--;
     } else if (input.data.buttons_d & Input::eButtons::BUTTON_A) {


### PR DESCRIPTION
A little QoL improvement for the toplevel (Config) menu: use dpad left/rigt to navigate a full page up or down. This makes it much faster to reach a plugin in the middle of the list.