### PR TITLE
Add controls for viewing off-screen GUI text

### DIFF
--- a/source/utils/config/CategoryRenderer.cpp
+++ b/source/utils/config/CategoryRenderer.cpp
@@ -82,10 +82,13 @@ ConfigSubState CategoryRenderer::UpdateStateMain(Input &input, const WUPSConfigS
 
     if (mIsItemMovementAllowed) {
         if (input.data.buttons_d & Input::eButtons::BUTTON_DOWN) {
+            mItemRenderer[mCursorPos]->ResetTextOffset();
             mCursorPos++;
         } else if (input.data.buttons_d & Input::eButtons::BUTTON_UP) {
+            mItemRenderer[mCursorPos]->ResetTextOffset();
             mCursorPos--;
         } else if (input.data.buttons_d & Input::eButtons::BUTTON_A) {
+            mItemRenderer[mCursorPos]->ResetTextOffset();
             if (mCursorPos < (int32_t) mCat->getCategories().size()) {
                 if (mCurrentOpen != mCursorPos) {
                     mSubCategoryRenderer.reset();
@@ -96,6 +99,12 @@ ConfigSubState CategoryRenderer::UpdateStateMain(Input &input, const WUPSConfigS
                 mNeedsRedraw = true;
                 return SUB_STATE_RUNNING;
             }
+        } else if ((input.data.buttons_h & Input::eButtons::STICK_L_RIGHT) || (input.data.buttons_h & Input::eButtons::STICK_R_RIGHT)) {
+            mItemRenderer[mCursorPos]->IncrementTextOffset();
+            mNeedsRedraw = true;
+        } else if ((input.data.buttons_h & Input::eButtons::STICK_L_LEFT) || (input.data.buttons_h & Input::eButtons::STICK_R_LEFT)) {
+            mItemRenderer[mCursorPos]->DecrementTextOffset();
+            mNeedsRedraw = true;
         }
     }
 
@@ -216,8 +225,10 @@ void CategoryRenderer::RenderStateMain() const {
     RenderMainLayout();
 
     uint32_t yOffset = 8 + 24 + 8 + 4;
+
     for (int32_t i = start; i < end; i++) {
         bool isHighlighted = (i == mCursorPos);
+
         mItemRenderer[i]->Draw(yOffset, isHighlighted);
         yOffset += 42 + 8;
     }

--- a/source/utils/config/ConfigRendererItem.h
+++ b/source/utils/config/ConfigRendererItem.h
@@ -10,8 +10,10 @@ public:
 
     void Draw(uint32_t yOffset, bool isHighlighted) const override {
         assert(mItem);
-        drawGenericBoxAndText(yOffset, mItem->getDisplayName(), isHighlighted);
+
+        drawGenericBoxAndText(yOffset, ConfigRenderItemFont::GetOffsettedText(mItem->getDisplayName(), mTextOffset), isHighlighted);
         DrawUtils::setFontSize(24);
+
         DrawUtils::print(SCREEN_WIDTH - 16 * 2, yOffset + 8 + 24, mCurItemText.c_str(), true);
     }
 
@@ -40,6 +42,24 @@ public:
         mItem->onSelected(isSelected);
     }
 
+    void ResetTextOffset() override {
+        mTextOffset = 0;
+    }
+
+    uint32_t GetTextOffset() const override {
+        return mTextOffset;
+    }
+
+    void IncrementTextOffset() override {
+        if (!mItem) return;
+        ConfigRenderItemFont::IncrementOffset(mItem->getDisplayName(), mTextOffset);
+    }
+
+    void DecrementTextOffset() override {
+        if (!mItem) return;
+        if (mTextOffset > 0) mTextOffset--;
+    }
+
     void OnButtonPressed(WUPSConfigButtons buttons) override {
         mItem->onButtonPressed(buttons);
     }
@@ -58,5 +78,6 @@ public:
 private:
     const WUPSConfigAPIBackend::WUPSConfigItem *mItem;
     std::string mCurItemText;
-    bool mNeedsDraw = true;
+    bool mNeedsDraw      = true;
+    uint32_t mTextOffset = 0;
 };

--- a/source/utils/config/ConfigRendererItemCategory.h
+++ b/source/utils/config/ConfigRendererItemCategory.h
@@ -4,12 +4,12 @@
 
 class ConfigRendererItemCategory : public ConfigRendererItemGeneric {
 public:
-    explicit ConfigRendererItemCategory(const WUPSConfigAPIBackend::WUPSConfigCategory *category) : mCategory(category) {
+    explicit ConfigRendererItemCategory(const WUPSConfigAPIBackend::WUPSConfigCategory *category) : mCategory(category), mTextOffset(0) {
         assert(category);
     }
 
     void Draw(uint32_t yOffset, bool isHighlighted) const override {
-        drawGenericBoxAndText(yOffset, mCategory->getName(), isHighlighted);
+        drawGenericBoxAndText(yOffset, ConfigRenderItemFont::GetOffsettedText(mCategory->getName(), mTextOffset), isHighlighted);
     }
 
     void Update(bool) override {
@@ -22,6 +22,24 @@ public:
     void ResetNeedsRedraw() override {
     }
 
+    void ResetTextOffset() override {
+        mTextOffset = 0;
+    }
+
+    uint32_t GetTextOffset() const override {
+        return mTextOffset;
+    }
+
+    void IncrementTextOffset() override {
+        if (!mCategory) return;
+        ConfigRenderItemFont::IncrementOffset(mCategory->getName(), mTextOffset);
+    }
+
+    void DecrementTextOffset() override {
+        if (mTextOffset > 0) mTextOffset--;
+    }
+
 private:
     const WUPSConfigAPIBackend::WUPSConfigCategory *mCategory;
+    uint32_t mTextOffset = 0;
 };

--- a/source/utils/config/ConfigRendererItemGeneric.h
+++ b/source/utils/config/ConfigRendererItemGeneric.h
@@ -3,6 +3,40 @@
 #include "ConfigDefines.h"
 #include <wups/config.h>
 
+namespace ConfigRenderItemFont {
+    constexpr uint32_t FONT_SIZE                 = 24;
+    constexpr uint32_t MIN_TEXT_WIDTH_FOR_SCROLL = 64;
+
+    inline void IncrementOffset(std::string text, uint32_t &offset) {
+        if (text.size() < MIN_TEXT_WIDTH_FOR_SCROLL) {
+            offset = 0;
+            return;
+        }
+
+        if (offset >= text.size()) {
+            offset = 0;
+            return;
+        }
+
+        text.erase(0, offset);
+        if (text.size() < MIN_TEXT_WIDTH_FOR_SCROLL) {
+            offset = 0;
+            return;
+        }
+
+        offset++;
+    }
+
+    inline std::string GetOffsettedText(const std::string &text, uint32_t offset) {
+        if (text.size() < MIN_TEXT_WIDTH_FOR_SCROLL || offset == 0) return text;
+
+        std::string offsettedText = text;
+        offsettedText.erase(0, offset);
+
+        return offsettedText;
+    }
+} // namespace ConfigRenderItemFont
+
 class ConfigRendererItemGeneric {
 public:
     virtual ~ConfigRendererItemGeneric() = default;
@@ -13,9 +47,10 @@ public:
             DrawUtils::drawRect(16, yOffset, SCREEN_WIDTH - 16 * 2, 44, 2, COLOR_BORDER);
         }
 
-        DrawUtils::setFontSize(24);
+        DrawUtils::setFontSize(ConfigRenderItemFont::FONT_SIZE);
+
         DrawUtils::setFontColor(COLOR_TEXT);
-        DrawUtils::print(16 * 2, yOffset + 8 + 24, displayName.c_str());
+        DrawUtils::print(16 * 2, yOffset + 8 + ConfigRenderItemFont::FONT_SIZE, displayName.c_str());
     }
 
     virtual void Draw(uint32_t yOffset, bool isHighlighted) const = 0;
@@ -29,7 +64,16 @@ public:
     virtual void SetIsSelected(bool) {
     }
 
-    virtual void OnButtonPressed(WUPSConfigButtons) {
+    virtual void ResetTextOffset() = 0;
+
+    virtual uint32_t GetTextOffset() const {
+        return 0;
+    }
+    virtual void IncrementTextOffset() = 0;
+    virtual void DecrementTextOffset() = 0;
+
+    virtual void
+    OnButtonPressed(WUPSConfigButtons) {
     }
     virtual void OnInput(WUPSConfigSimplePadData) {
     }


### PR DESCRIPTION
# Description

This PR adds controls for viewing off-screen GUI text for all GUI elements. The "zoomed" text gets erased when switching the selected element.

# Controls

- R / L Stick: View rightmost text