### PR TITLE
Added `WUPSConfigAPI_GetMenuOpen()` to allow plugins to check if the menu is open.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/wiiu-env/devkitppc:20240704
 
 COPY --from=ghcr.io/wiiu-env/wiiumodulesystem:20240424 /artifacts $DEVKITPRO
-COPY --from=ghcr.io/wiiu-env/wiiupluginsystem:0.8.2-dev-20241128-1ac579a $DEVKITPRO
+COPY --from=ghcr.io/wiiu-env/wiiupluginsystem:0.8.2-dev-20241128-1ac579a /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libfunctionpatcher:20230621 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libmappedmemory:20230621 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libwupsbackend:20240425 /artifacts $DEVKITPRO

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/wiiu-env/devkitppc:20240704
 
 COPY --from=ghcr.io/wiiu-env/wiiumodulesystem:20240424 /artifacts $DEVKITPRO
-COPY --from=ghcr.io/wiiu-env/wiiupluginsystem:20240505 /artifacts $DEVKITPRO
+COPY --from=ghcr.io/wiiu-env/wiiupluginsystem:0.8.2-dev-20241128-1ac579a $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libfunctionpatcher:20230621 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libmappedmemory:20230621 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libwupsbackend:20240425 /artifacts $DEVKITPRO

--- a/source/config/WUPSConfigAPI.cpp
+++ b/source/config/WUPSConfigAPI.cpp
@@ -311,16 +311,18 @@ namespace WUPSConfigAPIBackend {
         return WUPSCONFIG_API_RESULT_SUCCESS;
     }
 
-    WUPSConfigAPIStatus WUPSConfigAPI_GetMenuOpen(BOOL *out) {
-        if (out == nullptr) {
+    WUPSConfigAPIStatus WUPSConfigAPI_Menu_GetStatus(WUPSConfigAPIMenuStatus *status) {
+        if (status == nullptr) {
             return WUPSCONFIG_API_RESULT_INVALID_ARGUMENT;
         }
-        *out = gConfigMenuOpened;
+        *status = gConfigMenuOpened
+            ? WUPSCONFIG_API_MENU_STATUS_OPENED
+            : WUPSCONFIG_API_MENU_STATUS_CLOSED;
         return WUPSCONFIG_API_RESULT_SUCCESS;
     }
 
     WUMS_EXPORT_FUNCTION(WUPSConfigAPI_GetVersion);
-    WUMS_EXPORT_FUNCTION(WUPSConfigAPI_GetMenuOpen);
+    WUMS_EXPORT_FUNCTION(WUPSConfigAPI_Menu_GetStatus);
 
     WUMS_EXPORT_FUNCTION_EX(WUPSConfigAPIBackend::InitEx, WUPSConfigAPI_InitEx);
     WUMS_EXPORT_FUNCTION_EX(WUPSConfigAPIBackend::Category::Create, WUPSConfigAPI_Category_CreateEx);

--- a/source/config/WUPSConfigAPI.cpp
+++ b/source/config/WUPSConfigAPI.cpp
@@ -311,7 +311,12 @@ namespace WUPSConfigAPIBackend {
         return WUPSCONFIG_API_RESULT_SUCCESS;
     }
 
+    BOOL WUPSConfigAPI_IsMenuOpen(void) {
+        return gConfigMenuOpened;
+    }
+
     WUMS_EXPORT_FUNCTION(WUPSConfigAPI_GetVersion);
+    WUMS_EXPORT_FUNCTION(WUPSConfigAPI_IsMenuOpen);
 
     WUMS_EXPORT_FUNCTION_EX(WUPSConfigAPIBackend::InitEx, WUPSConfigAPI_InitEx);
     WUMS_EXPORT_FUNCTION_EX(WUPSConfigAPIBackend::Category::Create, WUPSConfigAPI_Category_CreateEx);

--- a/source/config/WUPSConfigAPI.cpp
+++ b/source/config/WUPSConfigAPI.cpp
@@ -311,12 +311,16 @@ namespace WUPSConfigAPIBackend {
         return WUPSCONFIG_API_RESULT_SUCCESS;
     }
 
-    BOOL WUPSConfigAPI_IsMenuOpen(void) {
-        return gConfigMenuOpened;
+    WUPSConfigAPIStatus WUPSConfigAPI_GetMenuOpen(BOOL *out) {
+        if (out == nullptr) {
+            return WUPSCONFIG_API_RESULT_INVALID_ARGUMENT;
+        }
+        *out = gConfigMenuOpened;
+        return WUPSCONFIG_API_RESULT_SUCCESS;
     }
 
     WUMS_EXPORT_FUNCTION(WUPSConfigAPI_GetVersion);
-    WUMS_EXPORT_FUNCTION(WUPSConfigAPI_IsMenuOpen);
+    WUMS_EXPORT_FUNCTION(WUPSConfigAPI_GetMenuOpen);
 
     WUMS_EXPORT_FUNCTION_EX(WUPSConfigAPIBackend::InitEx, WUPSConfigAPI_InitEx);
     WUMS_EXPORT_FUNCTION_EX(WUPSConfigAPIBackend::Category::Create, WUPSConfigAPI_Category_CreateEx);

--- a/source/config/WUPSConfigAPI.cpp
+++ b/source/config/WUPSConfigAPI.cpp
@@ -316,8 +316,8 @@ namespace WUPSConfigAPIBackend {
             return WUPSCONFIG_API_RESULT_INVALID_ARGUMENT;
         }
         *status = gConfigMenuOpened
-            ? WUPSCONFIG_API_MENU_STATUS_OPENED
-            : WUPSCONFIG_API_MENU_STATUS_CLOSED;
+                          ? WUPSCONFIG_API_MENU_STATUS_OPENED
+                          : WUPSCONFIG_API_MENU_STATUS_CLOSED;
         return WUPSCONFIG_API_RESULT_SUCCESS;
     }
 

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -17,3 +17,5 @@ bool gNotificationModuleLoaded = false;
 OSThread *gOnlyAcceptFromThread = nullptr;
 
 bool gConfigMenuShouldClose = false;
+
+bool gConfigMenuOpened = false;

--- a/source/globals.h
+++ b/source/globals.h
@@ -30,3 +30,5 @@ extern bool gNotificationModuleLoaded;
 extern OSThread *gOnlyAcceptFromThread;
 
 extern bool gConfigMenuShouldClose;
+
+extern bool gConfigMenuOpened;

--- a/source/utils/schrift.c
+++ b/source/utils/schrift.c
@@ -1108,11 +1108,11 @@ simple_outline(SFT_Font *font, uint_fast32_t offset, unsigned int numContours, O
             goto failure;
     }
 
-    endPts = calloc(sizeof(uint_fast16_t), numContours);
+    endPts = calloc(numContours, sizeof(uint_fast16_t));
     if (endPts == NULL) {
         goto failure;
     }
-    flags = calloc(sizeof(uint8_t), numPts);
+    flags = calloc(numPts, sizeof(uint8_t));
     if (flags == NULL) {
         goto failure;
     }
@@ -1433,11 +1433,10 @@ render_outline(Outline *outl, double transform[6], SFT_Image image) {
 
     numPixels = (unsigned int) image.width * (unsigned int) image.height;
 
-    cells = calloc(sizeof(Cell), numPixels);
+    cells = calloc(numPixels, sizeof(Cell));
     if (!cells) {
         return -1;
     }
-    memset(cells, 0, numPixels * sizeof *cells);
     buf.cells  = cells;
     buf.width  = image.width;
     buf.height = image.height;


### PR DESCRIPTION
This new function allows a plugin to check if the config menu is open. It's now possible for a plugin to change behavior when the user is trying to interact with the menu.