### PR TITLE
Remove the global trampoline table and add a small trampoline table next to each .text section instead

### DIFF
--- a/source/PluginManagement.h
+++ b/source/PluginManagement.h
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <map>
+#include <span>
 #include <string>
 
 class RelocationData;
@@ -15,18 +16,15 @@ class PluginContainer;
 class PluginManagement {
 public:
     static std::vector<PluginContainer> loadPlugins(
-            const std::vector<PluginLoadWrapper> &pluginDataList,
-            std::vector<relocation_trampoline_entry_t> &trampolineData);
+            const std::vector<PluginLoadWrapper> &pluginDataList);
 
     static void callInitHooks(const std::vector<PluginContainer> &plugins, const std::function<bool(const PluginContainer &)> &pred);
 
     static bool doRelocations(const std::vector<PluginContainer> &plugins,
-                              std::vector<relocation_trampoline_entry_t> &trampData,
                               std::map<std::string, OSDynLoad_Module> &usedRPls);
 
     static bool doRelocation(const std::vector<RelocationData> &relocData,
-                             std::vector<relocation_trampoline_entry_t> &trampData,
-                             uint32_t trampolineID,
+                             std::span<relocation_trampoline_entry_t> trampData,
                              std::map<std::string, OSDynLoad_Module> &usedRPls);
 
     static bool DoFunctionPatches(std::vector<PluginContainer> &plugins);

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -10,12 +10,10 @@
 #include "plugin/RelocationData.h"
 #include "plugin/SectionInfo.h"
 
-
 StoredBuffer gStoredTVBuffer  = {};
 StoredBuffer gStoredDRCBuffer = {};
 
 std::vector<PluginContainer> gLoadedPlugins;
-std::vector<relocation_trampoline_entry_t> gTrampData;
 
 std::set<std::shared_ptr<PluginData>, PluginDataSharedPtrComparator> gLoadedData;
 std::vector<PluginLoadWrapper> gLoadOnNextLaunch;

--- a/source/globals.h
+++ b/source/globals.h
@@ -24,8 +24,6 @@ class PluginLoadWrapper;
 extern StoredBuffer gStoredTVBuffer;
 extern StoredBuffer gStoredDRCBuffer;
 
-#define TRAMP_DATA_SIZE 1024
-extern std::vector<relocation_trampoline_entry_t> gTrampData;
 extern std::vector<PluginContainer> gLoadedPlugins;
 
 extern std::set<std::shared_ptr<PluginData>, PluginDataSharedPtrComparator> gLoadedData;

--- a/source/plugin/PluginLinkInformation.h
+++ b/source/plugin/PluginLinkInformation.h
@@ -20,12 +20,14 @@
 #include "FunctionSymbolData.h"
 #include "utils/HeapMemoryFixedSize.h"
 
+#include <iosfwd>
 #include <map>
 #include <optional>
 #include <set>
 #include <vector>
+#include <wums/defines/relocation_defines.h>
 
-class HeapMemoryFixedSize;
+class HeapMemoryFixedSizePool;
 class SectionInfo;
 class RelocationData;
 class FunctionData;
@@ -60,15 +62,17 @@ public:
 
     [[nodiscard]] std::optional<SectionInfo> getSectionInfo(const std::string &sectionName) const;
 
-    [[nodiscard]] uint8_t getTrampolineId() const;
-
     [[nodiscard]] const FunctionSymbolData *getNearestFunctionSymbolData(uint32_t address) const;
 
-    [[nodiscard]] const HeapMemoryFixedSize &getTextMemory() const;
+    [[nodiscard]] HeapMemoryFixedSizePool::MemorySegmentInfo getTextMemory() const;
 
-    [[nodiscard]] const HeapMemoryFixedSize &getDataMemory() const;
+    [[nodiscard]] HeapMemoryFixedSizePool::MemorySegmentInfo getDataMemory() const;
 
     [[nodiscard]] bool hasValidData() const;
+
+    [[nodiscard]] int numberOfSegments() const;
+
+    [[nodiscard]] std::span<relocation_trampoline_entry_t> getTrampData() const;
 
 private:
     PluginLinkInformation() = default;
@@ -83,18 +87,14 @@ private:
 
     void addSectionInfo(const SectionInfo &sectionInfo);
 
-    void setTrampolineId(uint8_t trampolineId);
-
     std::vector<HookData> mHookDataList;
     std::vector<FunctionData> mFunctionDataList;
     std::vector<RelocationData> mRelocationDataList;
     std::set<FunctionSymbolData, FunctionSymbolDataComparator> mSymbolDataList;
     std::map<std::string, SectionInfo> mSectionInfoList;
 
-    uint8_t mTrampolineId = 0;
-
-    HeapMemoryFixedSize mAllocatedTextMemoryAddress;
-    HeapMemoryFixedSize mAllocatedDataMemoryAddress;
+    HeapMemoryFixedSizePool mAllocatedTextAndTrampMemoryAddress;
+    HeapMemoryFixedSizePool mAllocatedDataMemoryAddress;
 
     friend class PluginLinkInformationFactory;
 };

--- a/source/plugin/PluginLinkInformationFactory.h
+++ b/source/plugin/PluginLinkInformationFactory.h
@@ -30,12 +30,12 @@ class PluginLinkInformation;
 class PluginLinkInformationFactory {
 public:
     static std::optional<PluginLinkInformation>
-    load(const PluginData &pluginData, std::vector<relocation_trampoline_entry_t> &trampolineData, uint8_t trampolineId);
+    load(const PluginData &pluginData);
 
 private:
     static bool
     linkSection(const ELFIO::elfio &reader, uint32_t section_index, uint32_t destination, uint32_t base_text, uint32_t base_data,
-                std::vector<relocation_trampoline_entry_t> &trampolineData, uint8_t trampolineId);
+                std::span<relocation_trampoline_entry_t> trampolineData);
 
     static bool
     addImportRelocationData(PluginLinkInformation &pluginInfo, const ELFIO::elfio &reader, std::span<uint8_t *> destinations);

--- a/source/utils/ElfUtils.h
+++ b/source/utils/ElfUtils.h
@@ -2,6 +2,8 @@
 
 #include <wums/defines/relocation_defines.h>
 
+#include <span>
+
 #include <cstdint>
 
 #ifdef __cplusplus
@@ -47,6 +49,6 @@ uint32_t load_loader_elf(unsigned char *baseAddress, char *elf_data, uint32_t fi
 class ElfUtils {
 
 public:
-    static bool elfLinkOne(char type, size_t offset, int32_t addend, uint32_t destination, uint32_t symbol_addr, std::vector<relocation_trampoline_entry_t> &trampolineData,
-                           RelocationType reloc_type, uint8_t trampolineId);
+    static bool elfLinkOne(char type, size_t offset, int32_t addend, uint32_t destination, uint32_t symbol_addr, std::span<relocation_trampoline_entry_t> trampolineData,
+                           RelocationType reloc_type);
 };

--- a/source/utils/HeapMemoryFixedSize.cpp
+++ b/source/utils/HeapMemoryFixedSize.cpp
@@ -1,33 +1,69 @@
 #include "HeapMemoryFixedSize.h"
 
+#include "logger.h"
 #include "utils.h"
 
-HeapMemoryFixedSize::HeapMemoryFixedSize() = default;
+HeapMemoryFixedSizePool::MemorySegmentInfo::MemorySegmentInfo(void *data, const size_t size) : mData(data),
+                                                                                               mSize(size) {}
 
-HeapMemoryFixedSize::HeapMemoryFixedSize(const std::size_t size) : mData(make_unique_nothrow<uint8_t[]>(size)), mSize(mData ? size : 0) {}
-
-HeapMemoryFixedSize::HeapMemoryFixedSize(HeapMemoryFixedSize &&other) noexcept
-    : mData(std::move(other.mData)), mSize(other.mSize) {
-    other.mSize = 0;
+void *HeapMemoryFixedSizePool::MemorySegmentInfo::data() const {
+    return mData;
 }
 
-HeapMemoryFixedSize &HeapMemoryFixedSize::operator=(HeapMemoryFixedSize &&other) noexcept {
+size_t HeapMemoryFixedSizePool::MemorySegmentInfo::size() const {
+    return mSize;
+}
+
+HeapMemoryFixedSizePool::HeapMemoryFixedSizePool() = default;
+
+HeapMemoryFixedSizePool::HeapMemoryFixedSizePool(const std::initializer_list<size_t> segmentSizes) : HeapMemoryFixedSizePool(std::span(segmentSizes.begin(), segmentSizes.size())) {}
+
+HeapMemoryFixedSizePool::HeapMemoryFixedSizePool(std::span<const std::size_t> segmentSizes) {
+    assert(!segmentSizes.empty());
+    size_t totalSize = 0;
+    for (const auto size : segmentSizes) {
+        totalSize += size + 0x40; // add 0x40 bytes overhead for each entry to ensure padding to 0x40
+    }
+
+    mData      = make_unique_nothrow<uint8_t[]>(totalSize);
+    mTotalSize = (mData ? totalSize : 0);
+    if (mData) {
+        auto address = reinterpret_cast<uint32_t>(mData.get());
+        for (const auto size : segmentSizes) {
+            address = ROUNDUP(address, 0x40);
+            assert(address >= reinterpret_cast<uint32_t>(mData.get()) && address < reinterpret_cast<uint32_t>(mData.get()) + totalSize);
+            mSegmentInfos.emplace_back(reinterpret_cast<void *>(address), size);
+            address += size;
+        }
+    }
+}
+
+HeapMemoryFixedSizePool::HeapMemoryFixedSizePool(HeapMemoryFixedSizePool &&other) noexcept
+    : mData(std::move(other.mData)), mTotalSize(other.mTotalSize), mSegmentInfos(std::move(other.mSegmentInfos)) {
+    other.mTotalSize = 0;
+}
+
+HeapMemoryFixedSizePool &HeapMemoryFixedSizePool::operator=(HeapMemoryFixedSizePool &&other) noexcept {
     if (this != &other) {
-        mData       = std::move(other.mData);
-        mSize       = other.mSize;
-        other.mSize = 0;
+        mData            = std::move(other.mData);
+        mTotalSize       = other.mTotalSize;
+        mSegmentInfos    = std::move(other.mSegmentInfos);
+        other.mTotalSize = 0;
     }
     return *this;
 }
 
-HeapMemoryFixedSize::operator bool() const {
-    return mData != nullptr;
+uint32_t HeapMemoryFixedSizePool::numberOfSegments() const {
+    return mSegmentInfos.size();
 }
 
-[[nodiscard]] const void *HeapMemoryFixedSize::data() const {
-    return mData.get();
+HeapMemoryFixedSizePool::operator bool() const {
+    return mData != nullptr && mTotalSize > 0;
 }
 
-[[nodiscard]] std::size_t HeapMemoryFixedSize::size() const {
-    return mSize;
+HeapMemoryFixedSizePool::MemorySegmentInfo HeapMemoryFixedSizePool::operator[](const int idx) const {
+    if (idx < 0 || idx >= static_cast<int>(mSegmentInfos.size())) {
+        DEBUG_FUNCTION_LINE_ERR("Out of bounce access (tried to access index %d; size is", idx, mSegmentInfos.size());
+    }
+    return mSegmentInfos[idx];
 }

--- a/source/utils/HeapMemoryFixedSize.h
+++ b/source/utils/HeapMemoryFixedSize.h
@@ -1,30 +1,45 @@
 #pragma once
 
 #include <memory>
+#include <span>
+#include <vector>
 
 #include <cstdint>
 
-class HeapMemoryFixedSize {
+class HeapMemoryFixedSizePool {
 public:
-    HeapMemoryFixedSize();
+    class MemorySegmentInfo {
+    public:
+        MemorySegmentInfo(void *data, size_t size);
 
-    explicit HeapMemoryFixedSize(std::size_t size);
+        [[nodiscard]] void *data() const;
+        [[nodiscard]] size_t size() const;
+
+    private:
+        void *mData;
+        size_t mSize;
+    };
+    HeapMemoryFixedSizePool();
+
+    HeapMemoryFixedSizePool(std::initializer_list<size_t> segmentSizes);
+    HeapMemoryFixedSizePool(std::span<const std::size_t> segmentSizes);
 
     // Delete the copy constructor and copy assignment operator
-    HeapMemoryFixedSize(const HeapMemoryFixedSize &) = delete;
-    HeapMemoryFixedSize &operator=(const HeapMemoryFixedSize &) = delete;
+    HeapMemoryFixedSizePool(const HeapMemoryFixedSizePool &) = delete;
+    HeapMemoryFixedSizePool &operator=(const HeapMemoryFixedSizePool &) = delete;
 
-    HeapMemoryFixedSize(HeapMemoryFixedSize &&other) noexcept;
+    HeapMemoryFixedSizePool(HeapMemoryFixedSizePool &&other) noexcept;
 
-    HeapMemoryFixedSize &operator=(HeapMemoryFixedSize &&other) noexcept;
+    HeapMemoryFixedSizePool &operator=(HeapMemoryFixedSizePool &&other) noexcept;
+
+    [[nodiscard]] uint32_t numberOfSegments() const;
 
     explicit operator bool() const;
 
-    [[nodiscard]] const void *data() const;
-
-    [[nodiscard]] std::size_t size() const;
+    MemorySegmentInfo operator[](int idx) const;
 
 private:
     std::unique_ptr<uint8_t[]> mData{};
-    std::size_t mSize{};
+    std::size_t mTotalSize{};
+    std::vector<MemorySegmentInfo> mSegmentInfos;
 };


### PR DESCRIPTION
This fixes wiiloading a plugin with a big .text section after a lot of aroma specific memory is used