### PR TITLE
Block on `VPADRead()` while the plugin menu is open.

### DIFF
--- a/source/patcher/hooks_patcher_static.cpp
+++ b/source/patcher/hooks_patcher_static.cpp
@@ -8,8 +8,10 @@
 #include "plugin/SectionInfo.h"
 #include "utils/config/ConfigUtils.h"
 
+#include <coreinit/cache.h>
 #include <coreinit/core.h>
 #include <coreinit/messagequeue.h>
+#include <coreinit/time.h>
 #include <padscore/wpad.h>
 #include <vpad/input.h>
 
@@ -21,9 +23,11 @@ DECL_FUNCTION(void, GX2SwapScanBuffers, void) {
 
     if (sWantsToOpenConfigMenu && !gConfigMenuOpened) {
         gConfigMenuOpened = true;
+        OSMemoryBarrier();
         ConfigUtils::openConfigMenu();
         gConfigMenuOpened      = false;
         sWantsToOpenConfigMenu = false;
+        OSMemoryBarrier();
     }
 }
 
@@ -89,6 +93,8 @@ DECL_FUNCTION(int32_t, VPADRead, int32_t chan, VPADStatus *buffer, uint32_t buff
     if (gConfigMenuOpened) {
         // Ignore reading vpad input only from other threads if the config menu is opened
         if (OSGetCurrentThread() != gOnlyAcceptFromThread) {
+            while (gConfigMenuOpened)
+                OSSleepTicks(OSMillisecondsToTicks(10));
             return 0;
         }
     }

--- a/source/patcher/hooks_patcher_static.cpp
+++ b/source/patcher/hooks_patcher_static.cpp
@@ -12,6 +12,7 @@
 #include <coreinit/core.h>
 #include <coreinit/messagequeue.h>
 #include <coreinit/time.h>
+#include <coreinit/title.h>
 #include <padscore/wpad.h>
 #include <vpad/input.h>
 
@@ -93,8 +94,14 @@ DECL_FUNCTION(int32_t, VPADRead, int32_t chan, VPADStatus *buffer, uint32_t buff
     if (gConfigMenuOpened) {
         // Ignore reading vpad input only from other threads if the config menu is opened
         if (OSGetCurrentThread() != gOnlyAcceptFromThread) {
-            while (gConfigMenuOpened)
-                OSSleepTicks(OSMillisecondsToTicks(10));
+            // Quick fix for Hyrule Warriors: block VPADRead() in non-rendering threads.
+            switch (OSGetTitleID()) {
+                case 0x00050000'1017CD00: // Hyrule Warriors JPN
+                case 0x00050000'1017D800: // Hyrule Warriors USA
+                case 0x00050000'1017D900: // Hyrule Warriors EUR
+                    while (gConfigMenuOpened)
+                        OSSleepTicks(OSMillisecondsToTicks(10));
+            }
             return 0;
         }
     }

--- a/source/utils/config/ConfigUtils.cpp
+++ b/source/utils/config/ConfigUtils.cpp
@@ -166,8 +166,8 @@ void ConfigUtils::displayMenu() {
     bool skipFirstInput = true;
 
     gOnlyAcceptFromThread              = OSGetCurrentThread();
-    OSMemoryBarrier();
     ConfigSubState subStateReturnValue = SUB_STATE_ERROR;
+    OSMemoryBarrier();
     while (true) {
         startTime = OSGetTime();
         if (gConfigMenuShouldClose) {

--- a/source/utils/config/ConfigUtils.cpp
+++ b/source/utils/config/ConfigUtils.cpp
@@ -20,6 +20,7 @@
 #include <wups/config.h>
 #include <wups/hooks.h>
 
+#include <coreinit/cache.h>
 #include <coreinit/title.h>
 #include <sysapp/launch.h>
 
@@ -165,6 +166,7 @@ void ConfigUtils::displayMenu() {
     bool skipFirstInput = true;
 
     gOnlyAcceptFromThread              = OSGetCurrentThread();
+    OSMemoryBarrier();
     ConfigSubState subStateReturnValue = SUB_STATE_ERROR;
     while (true) {
         startTime = OSGetTime();


### PR DESCRIPTION
Block on `VPADRead()` while the plugin menu is open. This pauses Hyrule Warriors while the menu is open, since its game logic runs independently from the graphics.